### PR TITLE
🐛 fix crash on app first startup

### DIFF
--- a/App.js
+++ b/App.js
@@ -95,7 +95,7 @@ const App = () => {
     loadData().then(res => {
       console.log('Startup::', res);
       if (!!res) {
-        setMasterData(res?.masterData);
+        setMasterData(res?.masterData ? res?.masterData : []);
         setSpendingHistory(res?.spendingHistory);
       }
       toggleLoading(false)

--- a/App.js
+++ b/App.js
@@ -95,7 +95,7 @@ const App = () => {
     loadData().then(res => {
       console.log('Startup::', res);
       if (!!res) {
-        setMasterData(res?.masterData ? res?.masterData : []);
+        setMasterData(res.masterData ?? []);
         setSpendingHistory(res?.spendingHistory);
       }
       toggleLoading(false)


### PR DESCRIPTION
On app first startup, `masterData` was null hence the app was being crashed.